### PR TITLE
implement helper, _create_instance() and _apply_triples()

### DIFF
--- a/src/reaction_KG.py
+++ b/src/reaction_KG.py
@@ -32,10 +32,7 @@ NCIT = Namespace('http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#')
 QUDT = Namespace('http://qudt.org/schema/qudt/')
 UNIT = Namespace('http://qudt.org/vocab/unit/')
 
-
-
 logger = logging.getLogger(__name__)
-
 
 class ReactionKG: 
     """A class that extracts and processes reaction data to be represented as a reaction knowledge graph. 
@@ -114,26 +111,16 @@ class ReactionKG:
         Returns:
             a created owlready2 instance
         """
-
         instance = ontology_class(instance_id)
 
-        #add type triple
         self.instance_dict['type'].append([instance.iri, instance.is_instance_of[0].iri])
-
-
         for prop_label, obj_value in  triples:
             self.instance_dict[prop_label].append([instance.iri, obj_value])
-
         return instance
 
     def _apply_triples(self, ontology_class, *triples):
-
-
         for prop_label, obj_value in triples:
             self.instance_dict[prop_label].append([ontology_class.iri, obj_value])
-
-
-
     
     def generate_reaction (self): 
         """Parses the reaction protocol buffer and populates the internal data lists. 
@@ -150,30 +137,24 @@ class ReactionKG:
             - :attr:`reaction_workups`
             - :attr:`reaction_provenances`
 
-
         Returns:
             :class:`ReactionKG`: The ReactionKG instance after the above lists have been populated with data from the instance's Protocol Buffer file
         """
 
-        # reaction identifiers 
         for identifier in self.reaction_pb.identifiers:
             identifier_dict = {'reactionID':self.reaction_id}
             identifier_dict.update({item: None for item in list(identifier.DESCRIPTOR.fields_by_name)})
             identifier_dict.update(message_to_row(identifier))
             self.reaction_identifiers.append(identifier_dict)
 
-        # reaction inputs, components, and compound identifiers
         for input in self.reaction_pb.inputs: 
 
             input_string = re.sub(r'\s+', '', str(input.strip()))
-
             reaction_input_dict = {'reactionID':self.reaction_id, 'InputKey':input_string}
-
             reaction_input_dict.update(message_to_row(self.reaction_pb.inputs[input]))
 
             # Get  possible fields 
             fields = list(self.reaction_pb.inputs[input].DESCRIPTOR.fields_by_name)
-
             # fill reaction inputs dict via loop
             try:
                 for s in fields:
@@ -181,14 +162,12 @@ class ReactionKG:
                     reaction_input_dict[s] = True if field_value else None
             except Exception as  e:
                 print("ERROR filling dict ", e)
-
             for ind, component in enumerate(self.reaction_pb.inputs[input].components): 
                 identifier_list, inchi_key = self.generate_compound_identifiers(component.identifiers)
                 if inchi_key:
                     reaction_input_dict[f"components[{ind}].INCHI_KEY"] = inchi_key
                 if component.amount:
                     reaction_input_dict[f"components[{ind}].amount.type"] = component.amount.WhichOneof('kind')
-
             self.reaction_inputs.append(reaction_input_dict)
 
         # reaction setup
@@ -211,7 +190,6 @@ class ReactionKG:
         for i in self.reaction_pb.conditions.DESCRIPTOR.fields_by_name:
             field_value = getattr(self.reaction_pb.conditions, i, None)
             if field_value: conditions_dict[str(i)] = True
-
         self.reaction_conditions.append(conditions_dict)
 
         # reaction notes
@@ -225,7 +203,6 @@ class ReactionKG:
             workups_dict = {'reactionID':self.reaction_id, 'Index':ind}
             workups_dict.update({item:None for item in list(workup.DESCRIPTOR.fields_by_name)})
             workups_dict.update(message_to_row(workup))
-
             if workup.input: 
                 workups_dict['input'] = True
                 for ind, component in enumerate(workup.input.components):
@@ -262,13 +239,11 @@ class ReactionKG:
                 for index, product in enumerate(outcome.products):
                     product_identifier, inchi_key = self.generate_compound_identifiers(product.identifiers)
                     outcome_dict[f"products[{index}].INCHI_KEY"] = inchi_key
-
             self.reaction_outcomes.append(outcome_dict)
 
         provenance_dict = {'reactionID': self.reaction_id}
         provenance_dict.update({item:None for item in list(self.reaction_pb.provenance.DESCRIPTOR.fields_by_name)})
         provenance_dict.update(message_to_row(self.reaction_pb.provenance))
-        
         return self
         
     def generate_compound_identifiers (self, identifiers): 
@@ -277,7 +252,6 @@ class ReactionKG:
         This method converts the ORD Identifiers Protocol Buffer message into a list of dictionaries. If **InChIKey** is not present, 
         it attempts to generate it (and potentially InChI/SMILES) from an existing InChI or SMILES identifier using **RDKit**.
         The generated identifiers are added to the list. The final InChIKey is attached to all identifier dictionaries in the list.
-
 
         Args:
             identifiers(:class:`ord_schema.proto.reaction_pb2.Identifiers`): The ORD Identifiers Protocol Buffer message to be processed into a list of dictionaries.
@@ -290,7 +264,6 @@ class ReactionKG:
 
         identifier_list = []
         desired_type = set()
-        
         for identifier in identifiers:
             identifier_dict = {item:None for item in list(identifier.DESCRIPTOR.fields_by_name)}
             identifier_dict.update(message_to_row(identifier))
@@ -424,12 +397,6 @@ class ReactionKG:
                 - :attr:`chemical_reaction`, :attr:`reaction_mixture, :attr:`reaction_environment`, :attr:`crude_product` (:class:`owlready2.Thing`): Core reaction instances
 
         """
-
-        print(f" -  DEBUG - within _initialize_instance_dict, attempting to load {onto_file_path} ...")
-        
-
-
-
         self.onto = get_ontology(onto_file_path).load()
 
         #get namespaces 
@@ -453,8 +420,6 @@ class ReactionKG:
         self.qudt = qudt
         self.unit = unit
 
-
-        
         # Setup and store units in unit_mapping dictionary to be used in other methods
         self.unit_mapping = {        
         'CELSIUS': self.unit.DEG_C,
@@ -491,10 +456,7 @@ class ReactionKG:
         'SECOND': self.unit.SEC,
 
         'PERCENTAGE': self.unit.PERCENT,
-
         }
-
-
 
         self.prop_metadata_dict = {}
 
@@ -515,16 +477,11 @@ class ReactionKG:
             self.instance_dict[str(prop.label[0])] = []
 
         self.instance_dict['type'] = []
-
-
         self.crude_product = self._create_instance(self.mds.CrudeProduct, 'CrudeProduct#' + self.reaction_id)
         self.chemical_reaction = self._create_instance(self.mds.ChemicalReaction, 'ChemicalReaction#' + self.reaction_id, ('has output', self.crude_product.iri))
         self.reaction_mixture = self._create_instance(self.mds.ReactionMixture, 'ReactionMixture#' + self.reaction_id, ('is input of', self.chemical_reaction.iri)) 
         self.reaction_environment = self._create_instance(self.mds.ReactionEnvironment, 'ReactionEnvironment#' + self.reaction_id, ('environs', self.chemical_reaction.iri))
 
-
-
-    
     def _extract_index_set(self, item_dict, pattern): 
         """Extract unique indices (either numeric or string keys) from dictionary keys based on regex pattern. 
 
@@ -586,14 +543,11 @@ class ReactionKG:
             #for CUSTOM reaction identifiers, add id and value
             if(item['type'] in ('UNSPECIFIED', 'CUSTOM')): 
                 self.instance_dict['has text value'].append([item['reactionID'], item['value']]) 
-
             if identifier_class == None:
                 identifier_type = 'Custom'
             else: 
                 identifier_type = re.sub(r'\s+', '', str(identifier_class.label[0]))
-
             if identifier_class: 
-
                 triples = [
                         ('designates', self.chemical_reaction.iri),
                         ('has text value', item['value']),
@@ -602,7 +556,6 @@ class ReactionKG:
                 if item['is_mapped']: triples.append(('is mapped', item['is_mapped']))
 
                 identifier = self._create_instance(identifier_class, f"{identifier_type}{self.reaction_id}", *triples)
-
             
     def _extract_components(self, component_list, process_node=None, context='input'):
         """Private method to process components (reactants, inputs, workup materials, or products).
@@ -635,7 +588,6 @@ class ReactionKG:
         """
 
         product_dict = {}
-
         if context == 'input': 
             pattern = rf'^components\[(\d+)\]'
             prefix = 'components'
@@ -792,7 +744,6 @@ class ReactionKG:
         ind_list = self._extract_index_set(component_list, pattern)
         if not ind_list: 
             return
-
         if context == 'input' or context == 'workup': 
             identifier_id_base = f'{self.reaction_id}_{component_list["InputKey"]}_component_{i}'
         elif context == 'product': 
@@ -829,7 +780,6 @@ class ReactionKG:
                     else:
                         identifier_type = re.sub(r'\s+', '', str(identifier_class.label[0]))
                     if identifier_class:
-
                         triples = [
                                 ('designates', reaction_component.iri),
                                 ('has text value', component_list[f"{prefix}[{i}].identifiers[{j}].value"]),
@@ -838,7 +788,6 @@ class ReactionKG:
                             triples.append(('details', component_list[f"{prefix}[{i}].identifiers[{j}].details"]))
                         if f"{prefix}[{i}].identifiers[{j}].is_mapped" in component_list: 
                             triples.append(('is mapped', component_list[f"{prefix}[{i}].identifiers[{j}].is_mapped"]))
-
                         identifier = self._create_instance(identifier_class, f"{identifier_type}#{identifier_id_base}_identifier_{j}", *triples)
                         
             except Exception as e: 
@@ -858,7 +807,6 @@ class ReactionKG:
         """
         
         for item in self.reaction_inputs:
-
             input_addition = self._create_instance(self.mds.InputAddition, f'InputAddition#{self.reaction_id}_{item["InputKey"]}', 
                     ('has output', self.reaction_mixture.iri))
             self._apply_triples(self.chemical_reaction, ('has process part', input_addition.iri))
@@ -897,7 +845,6 @@ class ReactionKG:
                         [('participates in', input_addition.iri)])
                 if 'addition_device.details' in item:  self._apply_triples(addition_device, item['addition_device.details'])
                 
-    
     def _process_temperature(self, component_list, reaction_component=None, context='condition'):
         """Processes temperature information associated with a reaction.
 
@@ -922,12 +869,10 @@ class ReactionKG:
         if context == 'condition' or context == 'workup': 
             prefix = 'temperature.setpoint'
             pattern = rf'^temperature\.measurements\[(\d+)\]'
-            
             if context == 'workup': 
                 reaction_temperature = self.cco.ont00000441(f'WorkupTemperature#{self.reaction_id}')
             elif context == 'condition':
                 reaction_temperature = self.mds.ReactionTemperature(f'ReactionTemperature#{self.reaction_id}')
-        
         elif context == 'input':
             reaction_temperature = self.cco.ont00000441(f'AdditionTemperature#{self.reaction_id}')
             prefix = 'addition_temperature'
@@ -1025,7 +970,6 @@ class ReactionKG:
                     reaction_atmosphere = self._create_instance(self.mds.ReactionAtmosphere, f"ReactionAtmosphere#{self.reaction_id}_{atmosphere_type}")
                     self._apply_triples(self.reaction_environment, ('is made of', reaction_atmosphere.iri))
 
-
             if item['stirring'] == True and 'stirring.type' in item :
                 stirring_condition = self._create_instance(self.obo.CHMO_0002774, f'StirringProcess#{self.reaction_id}')
                 self._apply_triples(self.chemical_reaction.iri, ('has process part', stirring_condition.iri))
@@ -1034,7 +978,6 @@ class ReactionKG:
                     stirring_rate = self._create_instance(self.mds.StirringRate, f'StirringRate#{self.reaction_id}',
                             ('details', item['stirring.rate.type']))
                     self._apply_triples(stirring_condition, ('has occurent part', stirring_rate.iri))
-
             
             if item['illumination'] == True and 'illumination.type' in item:
                 illumination_conditions = self._create_instance(self.mds.Illumination, f'IlluminationProcess#{self.reaction_id}')
@@ -1042,7 +985,6 @@ class ReactionKG:
                 if 'illumination.peak_wavelength.value' in item and 'illumination.peak_wavelength.units' in item:
                     peak_wavelength = self._create_instance(self.mds.PeakWavelength, f'PeakWavelength#{self.reaction_id}',('has decimal value', item['illumination.peak_wavelength']))
                     self._apply_triples(illumination_conditions, ('has occurent part', peak_wavelength.iri))
-
                 #if 'illumination.distance_to_vessel.value' in item and 'illumination.distance_to_vessel.units' in item: 
 
             if item['electrochemistry'] == True and 'electrochemistry.type' in item: 
@@ -1074,7 +1016,6 @@ class ReactionKG:
                 #if 'electrochemistry.cell.type' in item:
                 #    self.instance_dict[]
             if item['flow'] == True and 'flow.type' in item: 
-                #work on this if
                 flow_condition = self._create_instance(self.mds.ContinuousFlow, f'FlowConditions#{self.reaction_id}')
                 self._apply_triples(self.chemical_reaction, ('has process part', flow_condition.iri))
                 flow_triples = []
@@ -1229,7 +1170,6 @@ class ReactionKG:
 
                     if f"{product_prefix}[{j}].percentage.value" in outcome_list: 
                         triples.extend(('has decimal value',outcome_list[f"{product_prefix}[{j}].percentage.value"]), ('uses measurement unit',self.unit_mapping['PERCENTAGE'].iri))  
-                    
                     if f"{product_prefix}[{j}].float_value.value" in outcome_list: triples.append(('has decimal value',outcome_list[f"{product_prefix}[{j}].float_value.value"])) 
                     if f"{product_prefix}[{j}].string_value" in outcome_list: triples.append(('has text value',outcome_list[f"{product_prefix}[{j}].string_value"])) 
                     if outcome_list[f"{product_prefix}[{j}].type"] == 'AMOUNT' and f"{product_prefix}[{j}].amount.value" in outcome_list and f"{product_prefix}[{j}].amount.units" in outcome_list: 
@@ -1282,7 +1222,6 @@ class ReactionKG:
 
                 for analysis in analyses_set:
                     if f'analyses["{analysis}"].type' in item: 
-                        #here---------------------------------------------------------
                         analysis_type = self._create_instance(self.mds.AnalyticalTechnique, f'AnalyticalTechnique#{self.reaction_id}_{analysis}', ('details',item[f'analyses["{analysis}"].type'])) 
                     if f'analyses["{analysis}"].details' in item: self._apply_triples(analysis_type, ('details', item[f'analyses["{analysis}"].details']))
                     if f'analyses["{analysis}"].is_of_isolated_species' in item: 
@@ -1323,7 +1262,6 @@ class ReactionKG:
             reaction_setup = self.mds.ReactionSetup(f'ReactionSetup#{self.reaction_id}')
             self.instance_dict['precedes'].append([reaction_setup.iri, self.chemical_reaction.iri])
         
-
     def generate_data_graph(self, dataset_id, save_file_path): 
         """Generates the final RDF data graph and serializes it to a file.
 

--- a/src/reaction_KG.py
+++ b/src/reaction_KG.py
@@ -1021,88 +1021,67 @@ class ReactionKG:
                     triples_pressure.append(('details', item['pressure.control.type']))
                 reaction_pressure(self.mds.ReactionPressure, f'ReactionPressure#{self.reaction_id}', *triples_pressure)
                 if 'pressure.atmosphere.type' in item: 
-                    #
                     atmosphere_type = atmosphere_mapping.get(item['pressure.atmosphere.type'])
-                    reaction_atmosphere = self.mds.ReactionAtmosphere(f"ReactionAtmosphere#{self.reaction_id}_{atmosphere_type}")
-                    self.instance_dict['type'].append([reaction_atmosphere.iri, reaction_atmosphere.is_instance_of[0].iri])
-                    self.instance_dict['is made of'].append([self.reaction_environment.iri, reaction_atmosphere.iri])
+                    reaction_atmosphere = self._create_instance(self.mds.ReactionAtmosphere, f"ReactionAtmosphere#{self.reaction_id}_{atmosphere_type}")
+                    self._apply_triples(self.reaction_environment, ('is made of', reaction_atmosphere.iri))
 
-                    #works just convert these lines
-
-
-
-
-                #reaction_pressure = self.mds.ReactionPressure(f'ReactionPressure#{self.reaction_id}')
-                #self.instance_dict['type'].append([reaction_pressure.iri, reaction_pressure.is_instance_of[0].iri])
-                #self.instance_dict['has decimal value'].append([reaction_pressure.iri, item['pressure.setpoint.value']])
-                #self.instance_dict['bearer of'].append([self.reaction_environment.iri, reaction_pressure.iri])
-                #self.instance_dict['uses measurement unit'].append([reaction_pressure.iri, self.unit_mapping[item['pressure.setpoint.units']].iri])
-                #self.instance_dict['bearer of'].append([self.reaction_environment.iri, reaction_pressure.iri])
-                #if 'pressure.control.type' in item: 
-                    #self.instance_dict['details'].append([reaction_pressure.iri, item['pressure.control.type']])
-                #if 'pressure.atmosphere.type' in item: 
-                    #atmosphere_type = atmosphere_mapping.get(item['pressure.atmosphere.type'])
-                    #reaction_atmosphere = self.mds.ReactionAtmosphere(f"ReactionAtmosphere#{self.reaction_id}_{atmosphere_type}")
-                    #self.instance_dict['type'].append([reaction_atmosphere.iri, reaction_atmosphere.is_instance_of[0].iri])
-                    #self.instance_dict['is made of'].append([self.reaction_environment.iri, reaction_atmosphere.iri])
 
             if item['stirring'] == True and 'stirring.type' in item :
-                stirring_condition = self.obo.CHMO_0002774(f'StirringProcess#{self.reaction_id}')
-                self.instance_dict['type'].append([stirring_condition.iri, stirring_condition.is_instance_of[0].iri])
-                self.instance_dict['has process part'].append([self.chemical_reaction.iri, stirring_condition.iri])
+                stirring_condition = self._create_instance(self.obo.CHMO_0002774, f'StirringProcess#{self.reaction_id}')
+                self._apply_triples(self.chemical_reaction.iri, ('has process part', stirring_condition.iri))
+
                 if 'stirring.rate.type' in item:
-                    stirring_rate = self.mds.StirringRate(f'StirringRate#{self.reaction_id}')
-                    self.instance_dict['type'].append([stirring_rate.iri, stirring_rate.is_instance_of[0].iri])
-                    self.instance_dict['has occurent part'].append([stirring_condition.iri, stirring_rate.iri])
-                    self.instance_dict['details'].append([stirring_rate.iri, item['stirring.rate.type']])
+                    stirring_rate = self._create_instance(self.mds.StirringRate, f'StirringRate#{self.reaction_id}',
+                            ('details', item['stirring.rate.type']))
+                    self._apply_triples(stirring_condition, ('has occurent part', stirring_rate.iri))
+
             
             if item['illumination'] == True and 'illumination.type' in item:
-                illumination_conditions = self.mds.Illumination(f'IlluminationProcess#{self.reaction_id}')
-                self.instance_dict['type'].append([illumination_conditions.iri, illumination_conditions.is_instance_of[0].iri])
-                self.instance_dict['has process part'].append([self.chemical_reaction.iri, illumination_conditions.iri])
+                illumination_conditions = self._create_instance(self.mds.Illumination, f'IlluminationProcess#{self.reaction_id}')
+                self._apply_triples(self.chemical_reaction, ('has proccess part', illumination_conditions.iri))
                 if 'illumination.peak_wavelength.value' in item and 'illumination.peak_wavelength.units' in item:
-                    peak_wavelength = self.mds.PeakWavelength(f'PeakWavelength#{self.reaction_id}')
-                    self.instance_dict['type'].append([peak_wavelength.iri, peak_wavelength.is_instance_of[0].iri])
-                    self.instance_dict['has occurent part'].append([illumination_conditions.iri, peak_wavelength.iri])
-                    self.instance_dict['has decimal value'].append([peak_wavelength.iri, item['illumination.peak_wavelength.value']])
-                    self.instance_dict['uses measurement unit'].append([peak_wavelength.iri, item['illumination.peak_wavelength.units']])
+                    peak_wavelength = self._create_instance(self.mds.PeakWavelength, f'PeakWavelength#{self.reaction_id}',('has decimal value', item['illumination.peak_wavelength']))
+                    self._apply_triples(illumination_conditions, ('has occurent part', peak_wavelength.iri))
+
                 #if 'illumination.distance_to_vessel.value' in item and 'illumination.distance_to_vessel.units' in item: 
 
             if item['electrochemistry'] == True and 'electrochemistry.type' in item: 
-                electrochemistry_condition = self.mds.ElectrochemicalReaction(f'ElectrochemicalReaction#{self.reaction_id}')
-                self.instance_dict['type'].append([electrochemistry_condition.iri, electrochemistry_condition.is_instance_of[0].iri])
-                self.instance_dict['has process part'].append([self.chemical_reaction.iri, electrochemistry_condition.iri])
+
+                electrochemistry_condition = self._create_instance(self.mds.ElectrochemicalReaction, f'ElectrochemicalReaction#{self.reaction_id}')
+                self._apply_triples(self.chemical_reaction, ('has proccess part', electrochemistry_condition.iri))
+                triples = []
+
                 if 'electrochemistry.details' in item: 
-                    self.instance_dict['details'].append([electrochemistry_condition.iri, item['electrochemistry.details']])
+                    triples.append(('details', item['electrochemistry.details']))
                 if 'electrochemistry.current.value' in item and 'electrochemistry.current.units' in item:
-                    self.instance_dict['has decimal value'].append([electrochemistry_condition.iri, item['electrochemistry.current.value']])
-                    self.instance_dict['uses measurement unit'].append([electrochemistry_condition.iri, item['electrochemistry.current.units']])
+                    triples.append(('has decimal value', item['electrochemistry.current.value']))
+                    triples.append(('uses measurement unit', item['electrochemistry.current.units']))
                 if 'electrochemistry.voltage.value' in item and 'electrochemistry.voltage.units' in item:
-                    self.instance_dict['has decimal value'].append([electrochemistry_condition.iri, item['electrochemistry.voltage.value']])
-                    self.instance_dict['uses measurement unit'].append([electrochemistry_condition.iri, item['electrochemistry.voltage.units']])
+                    triples.append(('has decimal value', item['electrochemistry.voltage.value']))
+                    triples.append(('uses measurement unit', item['electrochemistry.voltage.units']))
                 if 'electrochemistry.anode_material' in item: 
-                    self.instance_dict['has text value'].append([electrochemistry_condition.iri, item['electrochemistry.anode_material']])
+                    triples.append(('has text value', item['electrochemistry.anode_material']))
                 if 'electrochemistry.cathode_material' in item: 
-                    self.instance_dict['has text value'].append([electrochemistry_condition.iri, item['electrochemistry.cathode_material']])
+                    triples.append(('has text value', item['electrochemistry.cathode_material']))
                 if 'electrochemistry.electrode_separation.value' in item and 'electrochemistry.electrode_separation.units' in item: 
-                    electrode_separation = self.cco.ont00000738(f"ElectrodeSeparation#{self.reaction_id}")
-                    self.instance_dict['type'].append([electrode_separation.iri, electrode_separation.is_instance_of[0].iri])
+                    electrode_separation = self._create_instance(self.cco.ont00000738, f"ElectrodeSeparation#{self.reaction_id}")
+                    triples.append(('has decimal value', item['electrochemistry.electrode_separation.value']))
+                    triples.append(('uses measurement unit', item['electrochemistry.electrode_separation.units']))
+                self._apply_triples(electrochemistry_condition, *triples)
                     #self.instance_dict['inheres in'].append([tube_diameter.iri, flow_tube.iri])
                     #self.instance_dict['has decimal value'].append([tube_diameter.iri, item['flow.tubing.diameter.value']])
                     #self.instance_dict['uses measurement unit'].append([tube_diameter.iri, item['flow.tubing.diamter.units']])
-                
-                    self.instance_dict['has decimal value'].append([electrochemistry_condition.iri, item['electrochemistry.electrode_separation.value']])
-                    self.instance_dict['uses measurement unit'].append([electrochemistry_condition.iri, item['electrochemistry.electrode_separation.units']])
                 #if 'electrochemistry.cell.type' in item:
                 #    self.instance_dict[]
             if item['flow'] == True and 'flow.type' in item: 
-                flow_condition = self.mds.ContinuousFlow(f'FlowConditions#{self.reaction_id}')
-                self.instance_dict['type'].append([flow_condition.iri, flow_condition.is_instance_of[0].iri])
-                self.instance_dict['has process part'].append([self.chemical_reaction.iri, flow_condition.iri])
+                #work on this if
+                flow_condition = self._create_instance(self.mds.ContinuousFlow, f'FlowConditions#{self.reaction_id}')
+                self._apply_triples(self.chemical_reaction, ('has process part', flow_condition.iri))
+                flow_triples = []
                 if 'flow.details' in item: 
-                    self.instance_dict['details'].append([flow_condition.iri, item['flow.details']])
+                    triples.append(('details', item['flow.details']))
                 if 'flow.pump_type' in item: 
-                    self.instance_dict['details'].append([flow_condition.iri, item['flow.pump_type']])
+                    triples.append(('details', item['flow.pump_type']))
                 if 'flow.tubing.type' in item: 
                     tube_mapping = {
                         'UNSPECIFIED': None,
@@ -1118,15 +1097,12 @@ class ReactionKG:
                         'SILICON': 'SiliconTube',
                         'PDMS': 'PolydimethylsiloxaneTube',
                     }
-                    flow_tube = self.cco.ont00000581(f"{tube_mapping[item['flow.tubing.type']]}#{self.reaction_id}")
-                    self.instance_dict['type'].append([flow_tube.iri, flow_tube.is_instance_of[0].iri])
-                    self.instance_dict['details'].append([flow_tube.iri, item['flow.tubing.details']]) if 'flow.tubing.details' in item else None
+                    flow_tube = self._create_instance(self.cco.ont00000581, f"{tube_mapping[item['flow.tubing.type']]}#{self.reaction_id}")
+                    if 'flow.tubing.details' in item: self._apply_triples(flow_tube, ('details', item['flow.tubing.details']))
                     if 'flow.tubing.diameter' in item and 'flow.tubing.diameter.value' in item and 'flow.tubing.diamter.units' in item:
-                        tube_diameter = self.cco.ont00000738(f"TubeDiameter#{self.reaction_id}")
-                        self.instance_dict['type'].append([tube_diameter.iri, tube_diameter.is_instance_of[0].iri])
-                        self.instance_dict['inheres in'].append([tube_diameter.iri, flow_tube.iri])
-                        self.instance_dict['has decimal value'].append([tube_diameter.iri, item['flow.tubing.diameter.value']])
-                        self.instance_dict['uses measurement unit'].append([tube_diameter.iri, item['flow.tubing.diamter.units']])
+                        tube_diameter = self._create_instance(self.cco.ont00000738, f"TubeDiameter#{self.reaction_id}", *[
+                            ('inheres in', flow_tube.iri),('has decimal value', item['flow.tubing.diameter.value']),
+                            ('uses measurement unit', item['flow.tubing.diameter.units'])])
     
     def _process_reaction_notes(self):
         """Processes key reaction notes and characteristics (:attr:`reaction_notes`).
@@ -1137,24 +1113,17 @@ class ReactionKG:
             None: Updates the :attr:`instance_dict` attribute.
         """
         for item in self.reaction_notes:
-            if 'is_heterogeneous' in item: 
-                self.instance_dict['is heterogeneous'].append([self.chemical_reaction.iri, item['is_heterogeneous']])
-            if 'forms_precipitate' in item: 
-                self.instance_dict['forms precipitate'].append([self.chemical_reaction.iri, item['forms_precipitate']])
-            if 'is_exothermic' in item: 
-                self.instance_dict['is exothermic'].append([self.chemical_reaction.iri, item['is_exothermic']])
-            if 'offgasses' in item: 
-                self.instance_dict['off gasses'].append([self.chemical_reaction.iri, item['offgasses']])
-            if 'is_sensitive_to_moisture' in item: 
-                self.instance_dict['is sensitive to moisture'].append([self.chemical_reaction.iri, item['is_sensitive_to_moisture']])
-            if 'is_sensitive_to_oxygen' in item: 
-                self.instance_dict['is sensitive to oxygen'].append([self.chemical_reaction.iri, item['is_sensitive_to_oxygen']])
-            if 'is_sensitive_to_light' in item: 
-                self.instance_dict['is sensitive to light'].append([self.chemical_reaction.iri, item['is_sensitive_to_light']])
-            if 'safety_notes' in item: 
-                self.instance_dict['safety notes'].append([self.chemical_reaction.iri, item['safety_notes']])
-            if 'procedure_details' in item: 
-                self.instance_dict['procedure details'].append([self.chemical_reaction.iri, item['procedure_details']])
+            triples = []
+            if 'is_heterogeneous' in item: triples.append(('is heterogeneous', item['is_heterogeneous']))
+            if 'forms_precipitate' in item: triples.append(('forms precipitate', item['forms_precipitate']))
+            if 'is_exothermic' in item: triples.append(('is exothermic', item['is_exothermic']))
+            if 'offgasses' in item: triples.append(('off gasses', item['offgasses']))
+            if 'is_sensitive_to_moisture' in item: triples.append(('is sensitive to moisture', item['is_sensitive_to_moisture']))
+            if 'is_sensitive_to_oxygen' in item: triples.append(('is sensitive to oxygen', item['is_sensitive_to_oxygen']))
+            if 'is_sensitive_to_light' in item: triples.append(('is sensitive to light', item['is_sensitive_to_light']))
+            if 'safety_notes' in item: triples.append(('safety notes',item['safety_notes']))
+            if 'procedure_details' in item: triples.append(('procedure details',item['procedure_details']))
+            self._apply_triples(self.chemical_reaction, *triples)
 
     def _process_reaction_workups(self):
         """Processes reaction workup steps (:attr:`reaction_workups`).
@@ -1188,15 +1157,13 @@ class ReactionKG:
         }
         for item in self.reaction_workups: 
             workup_type = workup_mapping.get(item['type'])
+            triples = []
             workup_instance = self.mds.ReactionWorkup(f'ReactionWorkup#{self.reaction_id}_{workup_type}_{item["Index"]}')
-            if item['details'] is not None: 
-                self.instance_dict['details'].append([workup_instance.iri, item['details']])
+            if item['details'] is not None: triples.append(('details', item['details']))
             if item['type'] == 'WAIT' and 'duration.value' in item and 'duration.units' in item: 
-                duration_instance = self.obo.BFO_0000202(f'WorkupDuration#{self.reaction_id}_{item["Index"]}')
-                self.instance_dict['type'].append([duration_instance.iri, duration_instance.is_instance_of[0].iri])
-                self.instance_dict['occupies temporal region'].append([workup_instance.iri, duration_instance.iri])
-                self.instance_dict['has datetime value'].append([duration_instance.iri, item['duration.value']])
-                self.instance_dict['uses measurement unit'].append([duration_instance.iri, self.unit_mapping[item['duration.units']].iri])
+                duration_instance = self._create_instance(self.obo.BFO_0000202,f'WorkupDuration#{self.reaction_id}_{item["Index"]}', *[
+                    ('has datetime value', item['duration.value']), ('uses measurement unit',self.unit_mapping[item['duration.units']].iri)])
+                triples.append(('occupies temporal region', duration_instance.iri))
             self.instance_dict['is input of'].append([self.crude_product.iri, workup_instance.iri])
             self.instance_dict['precedes'].append([self.chemical_reaction.iri, workup_instance.iri])
             if (item['type'] == 'ADDITION' or item['type'] ==  'DRY_WITH_MATERIAL' or item['type'] ==  'WASH' or item['type'] == 'SCAVENGING') and item['input'] == True:
@@ -1206,21 +1173,18 @@ class ReactionKG:
             if (item['type'] == 'TEMPERATURE' or item['type'] == 'DRY_IN_VACUUM' or item['type'] == 'DISTILLATION') and 'workup.temperature.setpoint.value' in item and 'workup.temperature.setpoint.units' in item : 
                 self._process_temperature(item, context='workup')
             if (item['type'] == 'EXTRACTION' or item['type'] == 'FILTRATION') and 'keep_phase' in item:
-                self.instance_dict['keep phase'].append([workup_instance.iri, item['keep_phase']])
+                triples.append(('keep phase', item['keep_phase']))
             if item['type'] == 'PH_ADJUST' and 'target_ph' in item: 
-                self.instance_dict['details'].append([workup_instance.iri, item['target_ph']])
+                triples.append(('details', item['target_ph']))
             if item['type'] == 'STIRRING' and item['stirring'] == True: 
-                stirring_condition = self.obo.CHMO_0002774(f'StirringProcess#{self.reaction_id}_Workup_{item["Index"]}')
-                self.instance_dict['type'].append([stirring_condition.iri, stirring_condition.is_instance_of[0].iri])
-                self.instance_dict['has process part'].append([workup_instance.iri, stirring_condition.iri])
+                stirring_condition = self._create_instance(self.obo.CHMO_0002774,f'StirringProcess#{self.reaction_id}_Workup_{item["Index"]}')
+                triples.append(('has process part', stirring_condition.iri))
                 if 'stirring.rate.type' in item:
-                    stirring_rate = self.mds.StirringRate(f'StirringRate#{self.reaction_id}')
-                    self.instance_dict['type'].append([stirring_rate.iri, stirring_rate.is_instance_of[0].iri])
-                    self.instance_dict['has occurent part'].append([stirring_condition.iri, stirring_rate.iri])
-                    self.instance_dict['details'].append([stirring_rate.iri, item['stirring.rate.type']])
+                    stirring_rate = self._create_instance(self.mds.StirringRate, f'StirringRate#{self.reaction_id}', ('details', item['stirring.rate.type']))
+                    triples.append(('has occurent part', stirring_rate.iri))
             if (item['type'] == 'FLASH_CHROMATOGRAPHY' or item['type'] == 'OTHER_CHROMATOGRAPHY') and 'is_automated' in item:
-                self.instance_dict['is automated'].append([workup_instance.iri, item['is_automated']])
-                
+                triples.append(('is automated', item['is_automated']))
+            self._apply_triples(workup_instance, *triples)
 
     def _extract_product_measurement(self, outcome_list, product_dict):
         """Processes the product measurements (results from analysis) within reaction outcomes.
@@ -1254,49 +1218,32 @@ class ReactionKG:
                 if i not in product_dict: 
                     continue
                 if f"{product_prefix}[{j}].type" in outcome_list and f"{product_prefix}[{j}].analysis_key" in outcome_list: 
-                    product_measurement = self.mds.AnalyticalResult(f'ProductMeasurement#{self.reaction_id}_{outcome_list[f"{product_prefix}[{j}].analysis_key"]}_Product_{i}_Measurement_{j}')
+                    product_measurement = self._create_instance(self.mds.AnalyticalResult, f'ProductMeasurement#{self.reaction_id}_{outcome_list[f"{product_prefix}[{j}].analysis_key"]}_Product_{i}_Measurement_{j}')
                     measurement_dict[outcome_list[f"{product_prefix}[{j}].analysis_key"]] = product_measurement
                 
                 elif f"{product_prefix}[{j}].type" in outcome_list: 
-                    product_measurement = self.mds.AnalyticalResult(f'ProductMeasurement#{self.reaction_id}_Product_{i}_Measurement_{j}')
-                else: 
-                    product_measurement = None
+                    product_measurement = self._create_instance(self.mds.AnalyticalResult,f'ProductMeasurement#{self.reaction_id}_Product_{i}_Measurement_{j}' )
                 if product_measurement: 
-                    self.instance_dict['type'].append([product_measurement.iri, product_measurement.is_instance_of[0].iri])
-                    self.instance_dict['is about'].append([product_measurement.iri, product_dict[i].iri])
+                    triples = []
+                    triples.append(('is about',product_dict[i].iri)) 
 
                     if f"{product_prefix}[{j}].percentage.value" in outcome_list: 
-                        self.instance_dict['has decimal value'].append([product_measurement.iri, outcome_list[f"{product_prefix}[{j}].percentage.value"]])
-                        self.instance_dict['uses measurement unit'].append([product_measurement.iri, self.unit_mapping['PERCENTAGE'].iri])
+                        triples.extend(('has decimal value',outcome_list[f"{product_prefix}[{j}].percentage.value"]), ('uses measurement unit',self.unit_mapping['PERCENTAGE'].iri))  
                     
-                    if f"{product_prefix}[{j}].float_value.value" in outcome_list: 
-                        self.instance_dict['has decimal value'].append([product_measurement.iri, outcome_list[f"{product_prefix}[{j}].float_value.value"]])
-
-                    if f"{product_prefix}[{j}].string_value" in outcome_list: 
-                        self.instance_dict['has text value'].append([product_measurement.iri, outcome_list[f"{product_prefix}[{j}].string_value"]])
-
+                    if f"{product_prefix}[{j}].float_value.value" in outcome_list: triples.append(('has decimal value',outcome_list[f"{product_prefix}[{j}].float_value.value"])) 
+                    if f"{product_prefix}[{j}].string_value" in outcome_list: triples.append(('has text value',outcome_list[f"{product_prefix}[{j}].string_value"])) 
                     if outcome_list[f"{product_prefix}[{j}].type"] == 'AMOUNT' and f"{product_prefix}[{j}].amount.value" in outcome_list and f"{product_prefix}[{j}].amount.units" in outcome_list: 
-                        amount_added = self.cco.ont00000768('Mass#' + outcome_list['reactionID'] + '_' + f"_Product_{str(i)}_Measurement_{str(j)}")
-                        self.instance_dict['type'].append([amount_added.iri, amount_added.is_instance_of[0].iri])
-                        self.instance_dict['inheres in'].append([amount_added.iri, product_dict[i].iri])
-                        self.instance_dict['is about'].append([product_measurement.iri, amount_added.iri])
-                        self.instance_dict['has decimal value'].append([product_measurement.iri, outcome_list[f"{product_prefix}[{j}].amount.value"]])
-                        self.instance_dict['uses measurement unit'].append([product_measurement.iri, self.unit_mapping[outcome_list[f"{product_prefix}[{j}].amount.units"]].iri])
-
+                        amount_added = self._create_instance(self.cco.ont00000768,'Mass#' + outcome_list['reactionID'] + '_' + f"_Product_{str(i)}_Measurement_{str(j)}", ('inheres in', product_dict[i].iri))
+                        triples.extend(('is about', amount_added.iri), ('has decimal value',outcome_list[f"{product_prefix}[{j}].amount.value"]), ('uses measurement unit',self.unit_mapping[outcome_list[f"{product_prefix}[{j}].amount.units"]].iri))  
                     if f"{product_prefix}[{j}].retention_time.value" in outcome_list and f"{product_prefix}[{j}].retention_time.units" in outcome_list: 
-                        retention_time = self.mds.RetentionTime('RetentionTime#' + outcome_list['reactionID'] + f"_Product_{str(i)}_Measurement_{str(j)}")
-                        self.instance_dict['type'].append([retention_time.iri, retention_time.is_instance_of[0].iri])
-                        self.instance_dict['is about'].append([retention_time.iri, product_dict[i].iri])
-                        self.instance_dict['is about'].append([product_measurement.iri, retention_time.iri])
-                        self.instance_dict['has datetime value'].append([retention_time.iri, outcome_list[f"{product_prefix}[{j}].retention_time.value"]])
-                        self.instance_dict['uses measurement unit'].append([retention_time.iri, self.unit_mapping[outcome_list[f"{product_prefix}[{j}].retention_time.units"]].iri])
-                    
-                    if f"{product_prefix}[{j}].uses_internal_standard" in outcome_list: 
-                        self.instance_dict['uses internal standard'].append([product_measurement.iri, outcome_list[f"{product_prefix}[{j}].uses_internal_standard"]])
-                    if f"{product_prefix}[{j}].uses_authentic_standard" in outcome_list:
-                        self.instance_dict['uses authentic standard'].append([product_measurement.iri, outcome_list[f"{product_prefix}[{j}].uses_authentic_standard"]])
-                    if f"{product_prefix}[{j}].is_normalized" in outcome_list:
-                        self.instance_dict['is normalized'].append([product_measurement.iri, outcome_list[f"{product_prefix}[{j}].is_normalized"]])
+                        retention_time = self._create_instance(self.mds.RetentionTime,'RetentionTime#' + outcome_list['reactionID'] + f"_Product_{str(i)}_Measurement_{str(j)}", *[
+                            ('is about', product_dict[i].iri), ('has datetime value',outcome_list[f"{product_prefix}[{j}].retention_time.value"]),
+                            ('uses measurement unit',self.unit_mapping[outcome_list[f"{product_prefix}[{j}].retention_time.units"]].iri)]) 
+                        triples.append(('is about', retention_time.iri))
+                    if f"{product_prefix}[{j}].uses_internal_standard" in outcome_list: triples.append(('uses internal standard', outcome_list[f"{product_prefix}[{j}].uses_internal_standard"]))
+                    if f"{product_prefix}[{j}].uses_authentic_standard" in outcome_list: triples.append(('uses authentic standard',outcome_list[f"{product_prefix}[{j}].uses_authentic_standard"]))
+                    if f"{product_prefix}[{j}].is_normalized" in outcome_list: triples.append(('is normalized',outcome_list[f"{product_prefix}[{j}].is_normalized"]))
+                    self._apply_triples(product_measurement, *triples)
         return self, measurement_dict
     
     def _process_reaction_outcomes(self):
@@ -1315,37 +1262,29 @@ class ReactionKG:
 
         for item in self.reaction_outcomes: 
             if item.get('reaction_time') == True and 'reaction_time.value'in item and 'reaction_time.units' in item:
-                reaction_time = self.mds.ReactionTime(f'ReactionTime#{self.reaction_id}')
-                self.instance_dict['type'].append([reaction_time.iri, reaction_time.is_instance_of[0].iri])
-                self.instance_dict['occupies temporal region'].append([self.chemical_reaction.iri, reaction_time.iri])
-                self.instance_dict['has datetime value'].append([reaction_time.iri, item['reaction_time.value']])
-                self.instance_dict['uses measurement unit'].append([reaction_time.iri, self.unit_mapping[item['reaction_time.units']].iri])
-            
+                reaction_time = self._create_instance(self.mds.ReactionTime,f'ReactionTime#{self.reaction_id}', *[
+                    ('has datetime value', item['reaction_time.value']), ('uses measurement unit', self.unit_mapping[item['reaction_time.units']].iri)])
+                self._apply_triples(self.chemical_reaction, ('occupies temporal region', reaction_time.iri))
+
             try: 
                 _, product_dict = self._extract_components(item, context='product')
             except Exception as e: 
                 logger.error(f"Failed to process product components into RDF triples for reaction {self.reaction_id}: {e}")
                 pass
-            
             try:
                 _, measurement_dict = self._extract_product_measurement(item, product_dict)
             except Exception as e:
                 logger.error(f"Failed to process product measurements into RDF triples for reaction {self.reaction_id}: {e}")
                 pass
-
             if item.get('analyses') == True: 
                 pattern = rf'^analyses\["([^"]*)"\]'  
                 analyses_set = self._extract_index_set(item, pattern)
 
                 for analysis in analyses_set:
                     if f'analyses["{analysis}"].type' in item: 
-                        analysis_type = self.mds.AnalyticalTechnique(f'AnalyticalTechnique#{self.reaction_id}_{analysis}')
-                        self.instance_dict['type'].append([analysis_type.iri, analysis_type.is_instance_of[0].iri])
-                        self.instance_dict['details'].append([analysis_type.iri, item[f'analyses["{analysis}"].type']])
-                        #self.instance_dict['has output'].append([analysis_type.iri, measurement_dict[analysis]])
-                    
-                    if f'analyses["{analysis}"].details' in item: 
-                        self.instance_dict['details'].append([analysis_type.iri, item[f'analyses["{analysis}"].details']])
+                        #here---------------------------------------------------------
+                        analysis_type = self._create_instance(self.mds.AnalyticalTechnique, f'AnalyticalTechnique#{self.reaction_id}_{analysis}', ('details',item[f'analyses["{analysis}"].type'])) 
+                    if f'analyses["{analysis}"].details' in item: self._apply_triples(analysis_type, ('details', item[f'analyses["{analysis}"].details']))
                     if f'analyses["{analysis}"].is_of_isolated_species' in item: 
                         self.instance_dict['is of isolated species'].append([analysis_type.iri, item[f'analyses["{analysis}"].is_of_isolated_species']])
                     #if f'analyses["{analysis}"].chmo_id' in item:

--- a/src/reaction_KG.py
+++ b/src/reaction_KG.py
@@ -100,6 +100,40 @@ class ReactionKG:
         self.reaction_environment = None
         self.crude_product = None
 
+
+    def _create_instance(self, ontology_class, instance_id, *triples):
+
+        """
+        creates ontology instance, addes triple for id and any provided triples
+
+        Args:
+            ontology_class: owl ready2 class to instantiate
+            instance_id (str): unqiue identifier for this instance
+            triples: variable number of triples to be added in tupble format (label, value)
+
+        Returns:
+            a created owlready2 instance
+        """
+
+        instance = ontology_class(instance_id)
+
+        #add type triple
+        self.instance_dict['type'].append([instance.iri, instance.is_instance_of[0].iri])
+
+
+        for prop_label, obj_value in  triples:
+            self.instance_dict[prop_label].append([instance.iri, obj_value])
+
+        return instance
+
+    def _apply_triples(self, ontology_class, *triples):
+
+
+        for prop_label, obj_value in triples:
+            self.instance_dict[prop_label].append([ontology_class.iri, obj_value])
+
+
+
     
     def generate_reaction (self): 
         """Parses the reaction protocol buffer and populates the internal data lists. 
@@ -240,7 +274,8 @@ class ReactionKG:
     def generate_compound_identifiers (self, identifiers): 
         """Processes a compound's identifiers and attempts to generate InChIKey, InChI, and SMILES strings for the compound.
 
-        This method converts the ORD Identifiers Protocol Buffer message into a list of dictionaries. If **InChIKey** is not present, it attempts to generate it (and potentially InChI/SMILES) from an existing InChI or SMILES identifier using **RDKit**.
+        This method converts the ORD Identifiers Protocol Buffer message into a list of dictionaries. If **InChIKey** is not present, 
+        it attempts to generate it (and potentially InChI/SMILES) from an existing InChI or SMILES identifier using **RDKit**.
         The generated identifiers are added to the list. The final InChIKey is attached to all identifier dictionaries in the list.
 
 
@@ -290,9 +325,11 @@ class ReactionKG:
         return identifier_list, inchi_key
     
     def generate_instances (self, onto_file_path): 
-        """Main method orchestrates all other methods - coordinates all instance generation.
+        """
+        Main method orchestrates all other methods - coordinates all instance generation.
 
-        Coordinates the initialization of the ontology environment and the sequential processing of all reaction data structures (lists of dictionaries) into semantically rich data instances based on MDS-Onto.
+        Coordinates the initialization of the ontology environment and the sequential processing of all reaction data structures (lists of dictionaries) into semantically rich data  instance
+        bassed MDS-Onto.
 
         The method calls private helper methods in a specific order: 
         :meth:`_initialize_instance_dict`, :meth:`_process_reaction_identifiers`, :meth:`_process_reaction_inputs`, :meth:`_process_reaction_conditions`, 
@@ -302,14 +339,17 @@ class ReactionKG:
             onto_file_path (str): A file path to the MDS-Onto (a domain ontology for Materials Data Science) owl file. 
         
         Returns
-            - self (:class:`ReactionKG`): The instance after processing with the attributes (:attr:`mds`, :attr:`cco`, :attr:`instance_dict`, etc.) populated with data instances based on the  MDS-Onto semantic model.
+            - self (:class:`ReactionKG`): The instance after processing with the attributes (:attr:`mds`, :attr:`cco`, :attr:`instance_dict`, etc.) populated with 
+            data instances based on the MDS-Onto semantic model.
 
         Notes
             Exceptions during processing are not raised. Instead, they are logged using the module logger and skipped.
-        """
+       """ 
+
         try: 
             self._initialize_instance_dict(onto_file_path)
         except Exception as e: 
+            raise ValueError(e)
             logger.error(f"Failed to initialize dictionaries of instances for reaction {self.reaction_id}: {e}")
             pass
         
@@ -366,8 +406,10 @@ class ReactionKG:
     def _initialize_instance_dict(self, onto_file_path): 
         """Initialization of the ontology environment, property metadata, and core reaction instances. 
 
-        Loads the OWL 2 ontology, establishes necesary namespaces (MDS, CCO, OBO, QUDT), creates a mapping for ORD enumeration units to QUDT units, and extracts all object/datatype properties into :attr:`prop_metadata_dict`. 
-        Finally it creates the core instances (:attr:`chemical_reaction`, :attr:`reaction_mixture, :attr:`reaction_environment`, :attr:`crude_product`) and populates the inital structure of :attr:`instance_dict`.
+        Loads the OWL 2 ontology, establishes necesary namespaces (MDS, CCO, OBO, QUDT), 
+        creates a mapping for ORD enumeration units to QUDT units, and extracts all object/datatype properties into :attr:`prop_metadata_dict`. 
+        Finally it creates the core instances (:attr:`chemical_reaction`, :attr:`reaction_mixture, :attr:`reaction_environment`, :attr:`crude_product`) 
+        and populates the inital structure of :attr:`instance_dict`.
         
         Args
             onto_file_path (str): A file path to the MDS-Onto (a domain ontology for Materials Data Science) owl (rdf/xml) file. 
@@ -390,10 +432,7 @@ class ReactionKG:
 
         self.onto = get_ontology(onto_file_path).load()
 
-        
-
-
-       
+        #get namespaces 
         self.onto.get_namespace('http://purl.allotrope.org/ontologies/equipment#')
         self.onto.get_namespace('http://purl.allotrope.org/ontologies/result#')
         self.onto.get_namespace('http://purl.allotrope.org/ontologies/role#')
@@ -409,7 +448,6 @@ class ReactionKG:
         
         # Store namespaces as instance variables for use in other methods
         self.mds = mds
-
         self.cco = cco
         self.obo = obo
         self.qudt = qudt
@@ -472,47 +510,20 @@ class ReactionKG:
         self.prop_metadata_dict['type'] = ('http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'Object Property')
         
         self.instance_dict = {}
-
-
-        
+    
         for prop in self.onto.properties():
             self.instance_dict[str(prop.label[0])] = []
+
         self.instance_dict['type'] = []
 
 
+        self.crude_product = self._create_instance(self.mds.CrudeProduct, 'CrudeProduct#' + self.reaction_id)
+        self.chemical_reaction = self._create_instance(self.mds.ChemicalReaction, 'ChemicalReaction#' + self.reaction_id, ('has output', self.crude_product.iri))
+        self.reaction_mixture = self._create_instance(self.mds.ReactionMixture, 'ReactionMixture#' + self.reaction_id, ('is input of', self.chemical_reaction.iri)) 
+        self.reaction_environment = self._create_instance(self.mds.ReactionEnvironment, 'ReactionEnvironment#' + self.reaction_id, ('environs', self.chemical_reaction.iri))
 
 
-        # Check if ReactionMixture exists in the namespace
-        print(f"mds.ReactionMixture is: {mds.ReactionMixture}")
-        print(f"Type of mds.ReactionMixture: {type(mds.ReactionMixture)}")
-        
-        # List all available classes in the namespace
-        print("\nAvailable classes in mds namespace:")
-        for attr_name in dir(mds):
-            attr = getattr(mds, attr_name)
-            if not attr_name.startswith('_') and hasattr(attr, '__class__'):
-                print(f"  {attr_name}: {type(attr)}")
 
-
-        self.chemical_reaction = self.mds.ChemicalReaction('ChemicalReaction#' + self.reaction_id)
-
-
-        self.reaction_mixture = self.mds.ReactionMixture('ReactionMixture#' + self.reaction_id)
-
-        print("reaction mix  ", self.chemical_reaction)
-
-        self.reaction_environment = self.mds.ReactionEnvironment('ReactionEnvironment#' + self.reaction_id)
-
-        self.crude_product = self.mds.CrudeProduct('CrudeProduct#' + self.reaction_id)
-        
-        self.instance_dict['type'].append([self.chemical_reaction.iri, self.chemical_reaction.is_instance_of[0].iri])
-        self.instance_dict['type'].append([self.reaction_mixture.iri, self.reaction_mixture.is_instance_of[0].iri])
-        self.instance_dict['type'].append([self.reaction_environment.iri, self.reaction_environment.is_instance_of[0].iri])
-        self.instance_dict['type'].append([self.crude_product.iri, self.crude_product.is_instance_of[0].iri])
-        
-        self.instance_dict['is input of'].append([self.reaction_mixture.iri, self.chemical_reaction.iri])
-        self.instance_dict['environs'].append([self.reaction_environment.iri, self.chemical_reaction.iri])
-        self.instance_dict['has output'].append([self.chemical_reaction.iri, self.crude_product.iri]) 
     
     def _extract_index_set(self, item_dict, pattern): 
         """Extract unique indices (either numeric or string keys) from dictionary keys based on regex pattern. 
@@ -571,26 +582,27 @@ class ReactionKG:
             
         for item in self.reaction_identifiers: 
             identifier_class = identifier_mapping.get(item['type'])
-            if(item['type'] in ('UNSPECIFIED', 'CUSTOM')): 
-                print("DEBUG IMPORTANTTTTT", item['type'])
-                print("this is the item", item)
 
+            #for CUSTOM reaction identifiers, add id and value
+            if(item['type'] in ('UNSPECIFIED', 'CUSTOM')): 
                 self.instance_dict['has text value'].append([item['reactionID'], item['value']]) 
 
             if identifier_class == None:
                 identifier_type = 'Custom'
-                print("DEBUG - mapping an calss not in ")
             else: 
                 identifier_type = re.sub(r'\s+', '', str(identifier_class.label[0]))
+
             if identifier_class: 
-                identifier = identifier_class(f"{identifier_type}{self.reaction_id}")
-                self.instance_dict['type'].append([identifier.iri, identifier.is_instance_of[0].iri])
-                self.instance_dict['designates'].append([identifier.iri, self.chemical_reaction.iri])
-                self.instance_dict['has text value'].append([identifier.iri, item['value']])
-                if item['details']: 
-                    self.instance_dict['details'].append([identifier.iri, item['details']])
-                if item['is_mapped']:
-                    self.instance_dict['is mapped'].append([identifier.iri, item['is_mapped']])
+
+                triples = [
+                        ('designates', self.chemical_reaction.iri),
+                        ('has text value', item['value']),
+                ]
+                if item['details']: triples.append(('details', item['details']))
+                if item['is_mapped']: triples.append(('is mapped', item['is_mapped']))
+
+                identifier = self._create_instance(identifier_class, f"{identifier_type}{self.reaction_id}", *triples)
+
             
     def _extract_components(self, component_list, process_node=None, context='input'):
         """Private method to process components (reactants, inputs, workup materials, or products).
@@ -817,14 +829,18 @@ class ReactionKG:
                     else:
                         identifier_type = re.sub(r'\s+', '', str(identifier_class.label[0]))
                     if identifier_class:
-                        identifier = identifier_class(f"{identifier_type}#{identifier_id_base}_identifier_{j}")
-                        self.instance_dict['designates'].append([identifier.iri, reaction_component.iri])
-                        self.instance_dict['type'].append([identifier.iri, identifier.is_instance_of[0].iri])
-                        self.instance_dict['has text value'].append([identifier.iri, component_list[f"{prefix}[{i}].identifiers[{j}].value"]])
+
+                        triples = [
+                                ('designates', reaction_component.iri),
+                                ('has text value', component_list[f"{prefix}[{i}].identifiers[{j}].value"]),
+                        ]
                         if f"{prefix}[{i}].identifiers[{j}].details" in component_list: 
-                            self.instance_dict['details'].append([identifier.iri, component_list[f"{prefix}[{i}].identifiers[{j}].details"]])
+                            triples.append(('details', component_list[f"{prefix}[{i}].identifiers[{j}].details"]))
                         if f"{prefix}[{i}].identifiers[{j}].is_mapped" in component_list: 
-                            self.instance_dict['is mapped'].append([identifier.iri, component_list[f"{prefix}[{i}].identifiers[{j}].is_mapped"]])
+                            triples.append(('is mapped', component_list[f"{prefix}[{i}].identifiers[{j}].is_mapped"]))
+
+                        identifier = self._create_instance(identifier_class, f"{identifier_type}#{identifier_id_base}_identifier_{j}", *triples)
+                        
             except Exception as e: 
                 logger.error(f"Failed to process identifier {j} for {prefix} {i} in reaction {self.reaction_id}: {e}")
                 continue
@@ -842,51 +858,45 @@ class ReactionKG:
         """
         
         for item in self.reaction_inputs:
-            input_addition = self.mds.InputAddition(f'InputAddition#{self.reaction_id}_{item["InputKey"]}')
-            self.instance_dict['type'].append([input_addition.iri, input_addition.is_instance_of[0].iri])
-            self.instance_dict['has process part'].append([self.chemical_reaction.iri, input_addition.iri])
-            self.instance_dict['has output'].append([input_addition.iri, self.reaction_mixture.iri])
-            
+
+            input_addition = self._create_instance(self.mds.InputAddition, f'InputAddition#{self.reaction_id}_{item["InputKey"]}', 
+                    ('has output', self.reaction_mixture.iri))
+            self._apply_triples(self.chemical_reaction, ('has process part', input_addition.iri))
+
             self._extract_components(item, input_addition)
             
             if item['addition_order']: 
-                self.instance_dict['addition order'].append([input_addition.iri, item['addition_order']])
-            
+                self._apply_triples(input_addition, ('addition order', item['addition_order']))
             if item['addition_speed'] == True and 'addition_speed.type' in item: 
-                addition_speed = self.mds.AdditionSpeed(f'AdditionSpeed#{self.reaction_id}')
-                self.instance_dict['type'].append([addition_speed.iri, addition_speed.is_instance_of[0].iri])
-                self.instance_dict['has occurent part'].append([input_addition.iri, addition_speed.iri])
-                self.instance_dict['has text value'].append([addition_speed.iri, item['addition_speed.type']])
-                if 'addition_speed.details' in item: 
-                    self.instance_dict['details'].append([addition_speed.iri, item['addition_speed.details']])
+                addition_speed = self._create_instance(self.mds.AdditionSpeed,f'AdditionSpeed#{self.reaction_id}', 
+                        ('has text value', item['addition_speed.type']))
+                if 'addition_speed.details' in item: self._apply_triples(addition_speed, ('details',item['addition_speed.details']))
+                self._apply_triples(input_addition, ('has occurent part', addition_speed.iri))
             
             if item['addition_duration'] == True and 'addition_duration.value' in item and 'addition_duration.units' in item:
-                addition_duration = self.obo.BFO_0000202(f'AdditionDuration#{self.reaction_id}')
-                self.instance_dict['type'].append([addition_duration.iri, addition_duration.is_instance_of[0].iri])
-                self.instance_dict['occupies temporal region'].append([input_addition.iri, addition_duration.iri])
-                self.instance_dict['has datetime value'].append([addition_duration.iri, item['addition_duration.value']])
-                self.instance_dict['uses measurement unit'].append([addition_duration.iri, self.unit_mapping[item['addition_duration.units']].iri])
-            
+                addition_duration = self._create_instance(self.obo.BFO_0000202, f'AdditionDuration#{self.reaction_id}',
+                    [('has datetime value',  item['addition_duration.value']),
+                     ('uses measurement unit', self.unit_mapping[item['addition_duration.units']].iri)
+                    ])
+                self._apply_triples(input_addition, ('occupies temporal region', addition_duration.iri))
+                    
             if item['addition_time'] == True and 'addition_time.value' in item and 'addition_time.units' in item:
-                addition_time = self.obo.BFO_0000202(f'AdditionTime#{self.reaction_id}')
-                self.instance_dict['type'].append([addition_time.iri, addition_time.is_instance_of[0].iri])
-                self.instance_dict['occupies temporal region'].append([input_addition.iri, addition_time.iri])
-                self.instance_dict['has datetime value'].append([addition_time.iri, item['addition_time.value']])
-                self.instance_dict['uses measurement unit'].append([addition_time.iri, self.unit_mapping[item['addition_time.units']].iri])
-
+                addition_time = self._create_instance(self.obo.BFO_0000202, f'AdditionTime#{self.reaction_id}', 
+                    [('has datetime value', item['addition_time.value']),
+                    ('uses measurement unit', self.unit_mapping[item['addition_time.units']].iri)])
+                self._apply_triples(input_addition, ('occupies temporal region',addition_time.iri))
+                    
             if item['flow_rate'] == True and 'flow_rate.value' in item and 'flow_rate.units' in item:
-                flow_rate = self.mds.FlowRate(f'FlowRate#{self.reaction_id}')
-                self.instance_dict['type'].append([flow_rate.iri, flow_rate.is_instance_of[0].iri])
-                self.instance_dict['has occurent part'].append([input_addition.iri, flow_rate.iri])
-                self.instance_dict['has decimal value'].append([flow_rate.iri, item['flow_rate.value']])
-                self.instance_dict['uses measurement unit'].append([flow_rate.iri, item['flow_rate.units']])
+                flow_rate = self._create_instance(self.mds.FLowRate, f'FlowRate#{self.reaction_id}', 
+                        [('has decimal value', item['flow_rate.value']),
+                        ('uses measurement unit', item['flow_rate.units'])])
+                self._apply_triples(input_addition, ('has occurent part', flow_rate.iri))
 
             if item['addition_device'] == True and 'addition_device.type' in item:
-                addition_device = self.cco.ont00000581(f"AdditionDevice#{self.reaction_id}_{item['addition_device.type']}")
-                self.instance_dict['type'].append([addition_device.iri, addition_device.is_instance_of[0].iri])
-                self.instance_dict['participates in'].append([addition_device.iri, input_addition.iri])
-                if 'addition_device.details' in item: 
-                    self.instance_dict['details'].append([addition_device.iri, item['addition_device.details']])
+                addition_device = self._create_instance(self.cco.ont00000581, f"AdditionDevice#{self.reaction_id}_{item['addition_device.type']}", 
+                        [('participates in', input_addition.iri)])
+                if 'addition_device.details' in item:  self._apply_triples(addition_device, item['addition_device.details'])
+                
     
     def _process_temperature(self, component_list, reaction_component=None, context='condition'):
         """Processes temperature information associated with a reaction.
@@ -928,17 +938,15 @@ class ReactionKG:
             raise ValueError(f"If _process_temperature method is used with {context}, reaction_component must be provided.")
 
         self.instance_dict['type'].append([reaction_temperature.iri, reaction_temperature.is_instance_of[0].iri])
-        temperature_measurement = self.mds.AnalyticalResult(f'TemperatureMeasurement#{self.reaction_id}_{context}')
-        self.instance_dict['type'].append([temperature_measurement.iri, temperature_measurement.is_instance_of[0].iri])
-        self.instance_dict['is about'].append([temperature_measurement.iri, reaction_temperature.iri])
 
-        self.instance_dict['has decimal value'].append([temperature_measurement.iri, component_list[f'{prefix}.value']])
-        self.instance_dict['uses measurement unit'].append([temperature_measurement.iri, self.unit_mapping[component_list[f'{prefix}.units']].iri])
-        
+        temperature_measurement = self._create_instance(self.mds.AnalyticalResult, f'TemperatureMeasurement#{self.reaction_id}_{context}',
+                *[('is about', reaction_temperature.iri),
+                ('has decimal value', component_list[f'{prefix}.value']),
+                ('uses measurement unit', self.unit_mapping[component_list[f'{prefix}.units']].iri)]) 
+               
         if f'{prefix}.control.type' in component_list and (context == 'input' or context == 'workup'): 
-            control_tool = self.cco.ont00000581(f'TemperatureControl#{self.reaction_id}_{component_list[f"{prefix}.control.type"]}')
-            self.instance_dict['type'].append([control_tool.iri, control_tool.is_instance_of[0].iri])
-            self.instance_dict['affects'].append([control_tool, reaction_temperature.iri])
+            control_tool = self._create_instance(self.cco.ont00000581, f'TemperatureControl#{self.reaction_id}_{component_list[f"{prefix}.control.type"]}',
+                    ('affects', reaction_temperature.iri))
         
         if context == 'condition':
             self.instance_dict['bearer of'].append([self.reaction_environment.iri, reaction_temperature.iri])
@@ -997,24 +1005,46 @@ class ReactionKG:
             'ETHYLENE': 'Ethylene',
             'ACETYLENE': 'Acetyle'
         }
+
+        #this is a big one!!!
         for item in self.reaction_conditions: 
             if item['temperature'] == True and 'temperature.setpoint.value' in item and 'temperature.setpoint.units' in item: 
                 self._process_temperature(item, context='condition')
                 
             if item['pressure'] == True and 'pressure.setpoint.value' in item and 'pressure.setpoint.units' in item: 
-                reaction_pressure = self.mds.ReactionPressure(f'ReactionPressure#{self.reaction_id}')
-                self.instance_dict['type'].append([reaction_pressure.iri, reaction_pressure.is_instance_of[0].iri])
-                self.instance_dict['has decimal value'].append([reaction_pressure.iri, item['pressure.setpoint.value']])
-                self.instance_dict['bearer of'].append([self.reaction_environment.iri, reaction_pressure.iri])
-                self.instance_dict['uses measurement unit'].append([reaction_pressure.iri, self.unit_mapping[item['pressure.setpoint.units']].iri])
-                self.instance_dict['bearer of'].append([self.reaction_environment.iri, reaction_pressure.iri])
+                
+                triples_pressure = [('has decimal value', item['pressure.setpoint.value']),
+                            ('uses measurement unit', self.unit_mapping[item['pressure.setpoint.units']].iri)]
+
+                triples_env = []
                 if 'pressure.control.type' in item: 
-                    self.instance_dict['details'].append([reaction_pressure.iri, item['pressure.control.type']])
+                    triples_pressure.append(('details', item['pressure.control.type']))
+                reaction_pressure(self.mds.ReactionPressure, f'ReactionPressure#{self.reaction_id}', *triples_pressure)
                 if 'pressure.atmosphere.type' in item: 
+                    #
                     atmosphere_type = atmosphere_mapping.get(item['pressure.atmosphere.type'])
                     reaction_atmosphere = self.mds.ReactionAtmosphere(f"ReactionAtmosphere#{self.reaction_id}_{atmosphere_type}")
                     self.instance_dict['type'].append([reaction_atmosphere.iri, reaction_atmosphere.is_instance_of[0].iri])
                     self.instance_dict['is made of'].append([self.reaction_environment.iri, reaction_atmosphere.iri])
+
+                    #works just convert these lines
+
+
+
+
+                #reaction_pressure = self.mds.ReactionPressure(f'ReactionPressure#{self.reaction_id}')
+                #self.instance_dict['type'].append([reaction_pressure.iri, reaction_pressure.is_instance_of[0].iri])
+                #self.instance_dict['has decimal value'].append([reaction_pressure.iri, item['pressure.setpoint.value']])
+                #self.instance_dict['bearer of'].append([self.reaction_environment.iri, reaction_pressure.iri])
+                #self.instance_dict['uses measurement unit'].append([reaction_pressure.iri, self.unit_mapping[item['pressure.setpoint.units']].iri])
+                #self.instance_dict['bearer of'].append([self.reaction_environment.iri, reaction_pressure.iri])
+                #if 'pressure.control.type' in item: 
+                    #self.instance_dict['details'].append([reaction_pressure.iri, item['pressure.control.type']])
+                #if 'pressure.atmosphere.type' in item: 
+                    #atmosphere_type = atmosphere_mapping.get(item['pressure.atmosphere.type'])
+                    #reaction_atmosphere = self.mds.ReactionAtmosphere(f"ReactionAtmosphere#{self.reaction_id}_{atmosphere_type}")
+                    #self.instance_dict['type'].append([reaction_atmosphere.iri, reaction_atmosphere.is_instance_of[0].iri])
+                    #self.instance_dict['is made of'].append([self.reaction_environment.iri, reaction_atmosphere.iri])
 
             if item['stirring'] == True and 'stirring.type' in item :
                 stirring_condition = self.obo.CHMO_0002774(f'StirringProcess#{self.reaction_id}')

--- a/src/reaction_KG.py
+++ b/src/reaction_KG.py
@@ -1019,7 +1019,7 @@ class ReactionKG:
                 triples_env = []
                 if 'pressure.control.type' in item: 
                     triples_pressure.append(('details', item['pressure.control.type']))
-                reaction_pressure(self.mds.ReactionPressure, f'ReactionPressure#{self.reaction_id}', *triples_pressure)
+                reaction_pressure = self._create_instance(self.mds.ReactionPressure, f'ReactionPressure#{self.reaction_id}', *triples_pressure)
                 if 'pressure.atmosphere.type' in item: 
                     atmosphere_type = atmosphere_mapping.get(item['pressure.atmosphere.type'])
                     reaction_atmosphere = self._create_instance(self.mds.ReactionAtmosphere, f"ReactionAtmosphere#{self.reaction_id}_{atmosphere_type}")


### PR DESCRIPTION
implements the _create_instance() and _apply_triples() method

**_create_instance()**
takes an ontology class and iri string, and adds it to the instance_dict, and also adds the 'type' to the instance dict


**_apply_triples()**
takes an ontology class and an array of arbitrary number of "triples". Each triple is actually a tuple containing the key and value stored in the instance dict, corresponds to predicate and object in a spo triple

These methods have been integrated into the reactionKG class, reducing redundant code and repetitive assignments to the instance_dict

Example:

flow_rate = self.mds.FlowRate(f'FlowRate#{self.reaction_id}')
self.instance_dict['type'].append([flow_rate.iri, flow_rate.is_instance_of[0].iri])
self.instance_dict['has decimal value'].append([flow_rate.iri, item['flow_rate.value']])
self.instance_dict['has decimal value'].append([flow_rate.iri, item['flow_vis.value']])
self.instance_dict['uses measurement unit'].append([flow_rate.iri, item['flow_rate.units']])

--> 

flow_rate = self._create_instance(self.mds.FlowRate, f'FlowRate#{self.reaction_id}', *[
('type', flow_rate.is_instance_of[0].iri), ('has decimal value', item['flow_rate.value']), ('uses measurement unit', item['flow_rate.units']), ('has decimal value', item['flow_vis.value'])])
